### PR TITLE
Initial accessibility fix-up for navigation

### DIFF
--- a/_includes/primary-nav-item.html
+++ b/_includes/primary-nav-item.html
@@ -5,7 +5,7 @@
 		<span class="c-primary-nav__text">{{ include.label }}</span>
 
 		{% if include.subgroup %}
-		<svg class="c-icon c-primary-nav__subicon">
+		<svg class="c-icon c-primary-nav__subicon" aria-hidden="true">
 			<use href="{{ "/icons.svg#chevron-right" | prepend: site.baseurl }}"></use>
 		</svg>
 		{% endif %}

--- a/_includes/primary-nav.html
+++ b/_includes/primary-nav.html
@@ -13,7 +13,7 @@
 
 				<span class="c-primary-nav__text">Guidelines</span>
 
-				<svg class="c-icon c-primary-nav__icon">
+				<svg class="c-icon c-primary-nav__icon" aria-hidden="true">
 					<use href="{{ "/icons.svg#chevron-right" | prepend: site.baseurl }}"></use>
 				</svg>
 
@@ -49,7 +49,7 @@
 
 				<span class="c-primary-nav__span">Styles</span>
 
-				<svg class="c-icon c-primary-nav__icon">
+				<svg class="c-icon c-primary-nav__icon" aria-hidden="true">
 					<use href="{{ "/icons.svg#chevron-right" | prepend: site.baseurl }}"></use>
 				</svg>
 
@@ -84,7 +84,7 @@
 
 				<span class="c-primary-nav__text">Components</span>
 
-				<svg class="c-icon c-primary-nav__icon">
+				<svg class="c-icon c-primary-nav__icon" aria-hidden="true">
 					<use href="{{ "/icons.svg#chevron-right" | prepend: site.baseurl }}"></use>
 				</svg>
 
@@ -136,7 +136,7 @@
 			<a href="{{ "/utilities/index.html" | prepend: site.baseurl }}" class="c-primary-nav__link c-primary-nav__link--has-children js-nav-dropdown-trigger {% if page.url contains '/utilities' %} is-active  is-current{% endif %}">
 
 				<span class="c-primary-nav__span">Utilities</span>
-				<svg class="c-icon c-primary-nav__icon">
+				<svg class="c-icon c-primary-nav__icon" aria-hidden="true">
 					<use href="{{ "/icons.svg#chevron-right" | prepend: site.baseurl }}"></use>
 				</svg>
 

--- a/js/style-guide.js
+++ b/js/style-guide.js
@@ -360,5 +360,17 @@
 	        }
 		});
 	}
+	
+	/**
+	 * Sets aria-current to the current navigation link
+	 * 1) Select all items denoted as current
+	 * 2) Add the aria-current attribute
+	 */
+	 
+	 	var navLink = document.querySelectorAll('.is-current'); /* 1 */
+	 
+	 	for (i=0; i<navLink.length; i++) { /* 1 */
+			navLink[i].setAttribute('aria-current', 'page'); /* 2 */
+		}
 
 })();

--- a/js/style-guide.js
+++ b/js/style-guide.js
@@ -265,9 +265,12 @@
 /**
  * Toggles active class on the primary nav item
  * 1) Select all nav dropdown triggers and cycle through them
- * 2) On click, find the nav dropdown trigger parent
- * 3) If the nav dropdown trigger parent already has active class, remove it.
- * 4) If the nav dropdown trigger parent does not have an active class, add it.
+ * 2) If not a button, add ARIA role and - to be safe - tabindex=0
+ * 3) Add explicit keyboard handling for SPACE (like a real <button>)
+ * 4) Add aria-expanded (based on initial state)
+ * 5) On click, find the nav dropdown trigger parent
+ * 6) If the nav dropdown trigger parent already has active class, remove it and set aria-expanded=false on toggle.
+ * 7) If the nav dropdown trigger parent does not have an active class, add it and set aria-expanded=true on toggle.
  */
 (function(){
 
@@ -275,15 +278,36 @@
 
 	for (i=0; i<navLink.length; i++) { /* 1 */
 
-		navLink[i].addEventListener('click',function(event){ /* 2 */
-	        event.preventDefault();
-	        var navLinkParent = this.parentNode; /* 2 */
+		if (navLink[i].nodeName != 'BUTTON') { /* 2 */
+			  navLink[i].setAttribute('role','button');
+				navLink[i].setAttribute('tabindex','0');
+				
+				navLink[i].addEventListener('keypress',function(event){ /* 3 */
+							if (event.keyCode == 32) {
+									event.preventDefault();
+									this.click();
+							}
+				});
+		}
+		
+		if (navLink[i].parentNode.classList.contains('is-active')) {  /* 4 */
+				navLink[i].setAttribute('aria-expanded','true');
+		}
+		else {
+				navLink[i].setAttribute('aria-expanded','false');
+		}
 
-	        if (navLinkParent.classList.contains('is-active')) { /* 3 */
+		navLink[i].addEventListener('click',function(event){ /* 5 */
+	        event.preventDefault();
+	        var navLinkParent = this.parentNode; /* 5 */
+
+	        if (navLinkParent.classList.contains('is-active')) { /* 6 */
 	            navLinkParent.classList.remove('is-active');
+							this.setAttribute('aria-expanded', 'false');
 	        }
-	        else { /* 4 */
+	        else { /* 7 */
 	            navLinkParent.classList.add('is-active');
+							this.setAttribute('aria-expanded', 'true');
 	        }
 		});
 	}
@@ -291,24 +315,48 @@
 	/**
 	 * Toggles active class on the primary nav panel
 	 * 1) Select all nav triggers and cycle through them
-	 * 2) On click, find the nav panel within the header
-	 * 3) If the navPanel already has active class, remove it on click.
-	 * 4) If the navPanel does not have an active class, add it on click.
+	 * 2) If not a button, add ARIA role and - to be safe - tabindex=0
+	 * 3) Add explicit keyboard handling for SPACE (like a real <button>)
+	 * 4) Add aria-expanded (based on initial state)
+	 * 5) On click, find the nav panel within the header
+	 * 6) If the navPanel already has active class, remove it and set aria-expanded=false on toggle.
+	 * 7) If the navPanel does not have an active class, add it and set aria-expanded=true on toggle.
 	 */
 	var navToggle = document.querySelectorAll('.js-nav-trigger');/* 1 */
 
 	for (i=0; i<navToggle.length; i++) { /* 1 */
 
-		navToggle[i].addEventListener('click',function(event){ /* 2 */
+		if (navToggle[i].nodeName != 'BUTTON') { /* 2 */
+			  navToggle[i].setAttribute('role','button');
+				navToggle[i].setAttribute('tabindex','0');
+				
+				navToggle[i].addEventListener('keypress',function(event){ /* 3 */
+							if (event.keyCode == 32) {
+									event.preventDefault();
+									this.click();
+							}
+				});
+		}
+		
+		if (navToggle[i].parentNode.classList.contains('is-active')) {  /* 4 */
+				navToggle[i].setAttribute('aria-expanded','true');
+		}
+		else {
+				navToggle[i].setAttribute('aria-expanded','false');
+		}
+		
+		navToggle[i].addEventListener('click',function(event){ /* 5 */
 	        event.preventDefault();
-	        var navToggleParent = this.parentNode; /* 2 */
-	        var navPanel = navToggleParent.querySelector('.js-nav-panel'); /* 2 */
+	        var navToggleParent = this.parentNode; /* 5 */
+	        var navPanel = navToggleParent.querySelector('.js-nav-panel'); /* 5 */
 
-	        if (navPanel.classList.contains('is-active')) { /* 3 */
+	        if (navPanel.classList.contains('is-active')) { /* 6 */
 	            navPanel.classList.remove('is-active');
+							this.setAttribute('aria-expanded', 'false');
 	        }
-	        else { /* 4 */
+	        else { /* 7 */
 	            navPanel.classList.add('is-active');
+							this.setAttribute('aria-expanded', 'true');
 	        }
 		});
 	}


### PR DESCRIPTION
- adds appropriate ARIA role and attributes for navigation disclosure widgets ("Menu" button, expand/collapse controls in left-hand nav)
- adds `aria-current="page"` to the current navigation item
- explicitly hides the navigation chevron SVGs from AT (as currently their `<title>` - "chevron-right" - can get announced by certain AT/browsers under certain conditions)